### PR TITLE
Remove reindeer covariate

### DIFF
--- a/R/assemble_inputData_PVA.R
+++ b/R/assemble_inputData_PVA.R
@@ -154,8 +154,7 @@ assemble_inputData_PVA <- function(Amax, Tmax, Tmax_sim, minYear,
     pertFac.mHs = perturbVecs$pertFac.mHs,
     pertFac.immR = perturbVecs$pertFac.immR,
     pertFac.rodent = perturbVecs$pertFac.rodent,
-    pertFac.reindeer = perturbVecs$pertFac.reindeer,
-    
+
     factor.mH.rodent = factor.mH.rodent,
     threshold.rodent.mH = threshold.rodent.mH,
     thresholdAbove = thresholdAbove

--- a/R/compareModels.R
+++ b/R/compareModels.R
@@ -147,7 +147,7 @@ compareModels <- function(Amax, Tmax, minYear, maxYear, logN = FALSE,
                   "betaHE.mH", 
                   "betaR.Psi", paste0("betaR.Psi[", 2:3, "]"),
                   "betaR.rho", paste0("betaR.rho[", 2:3, "]"),
-                  "betaRd.mO", "betaR.mO", "betaRxRd.mO"),
+                  "betaR.mO"),
     
     Imm = paste0("Imm[", 1:Tmax, "]"),
     

--- a/R/compareModels.R
+++ b/R/compareModels.R
@@ -160,7 +160,7 @@ compareModels <- function(Amax, Tmax, minYear, maxYear, logN = FALSE,
   
   ## Set parameters plotting time series of posterior summaries
   plotTS.paramsAge <- list(
-    ParamNames = c("mO", "S", "mH", "mHs", "Psi", "rho", "immR"),
+    ParamNames = c("mO", "S", "mH", "mHs", "Psi", "rho"),
     ParamLabels = c("Natural mortality", "Survival", 
                     "Harvest mortality", "Summer harvest mortality", "Pregnancy rate", "# fetuses/female")
   )

--- a/R/plotIPM_basicOutputs.R
+++ b/R/plotIPM_basicOutputs.R
@@ -213,9 +213,7 @@ plotIPM_basicOutputs <- function(MCMC.samples, nim.data, Amax, Tmax, minYear, lo
     rodent_wint       = nim.data$RodentAbundance[2:length(nim.data$RodentAbundance)], #because the first year is 2004 winter, which is NA, remove it so they are all the same length (19 rows).
     rodent_wint_time  = seq(as.Date(paste0(minYear,"-07-01")), as.Date(paste0(minYear+Tmax,"-07-01")), by="+1 year"), #because no rodent yearinfo in input data i had to do this manually...
     rodent_fall       = nim.data$RodentAbundance2,                                        # specific dates make sure that the bars and point arrive in approximately the right time in the year, because the year line is defined as june in the pop size plot
-    rodent_fall_time  = seq(as.Date(paste0(minYear,"-04-15")), as.Date(paste0(minYear+Tmax,"-04-15")), by="+1 year"),
-    reindeer          = nim.data$Reindeer,
-    reindeer_time     = seq(as.Date(paste0(minYear,"-07-01")), as.Date(paste0(minYear+Tmax,"-07-01")), by="+1 year")
+    rodent_fall_time  = seq(as.Date(paste0(minYear,"-04-15")), as.Date(paste0(minYear+Tmax,"-04-15")), by="+1 year")
   )
   
   
@@ -256,15 +254,14 @@ plotIPM_basicOutputs <- function(MCMC.samples, nim.data, Amax, Tmax, minYear, lo
   
   
   p.E_time <- ggplot(forplot)  +  
-    geom_bar(aes(x=reindeer_time, y=reindeer),stat="identity", fill="grey70",colour="grey70", width=250)+ 
     geom_line(aes(x=rodent_wint_time, y=rodent_wint),stat="identity",color="#005F94FF", linewidth=1)+
     geom_line(aes(x=rodent_fall_time, y=rodent_fall),stat="identity",color="#CF597EFF", linewidth=1)+
     labs(x="Year",y="Environmental covariates (scaled)")+ 
     scale_x_date(date_breaks = "1 year", date_labels = "%Y", minor_breaks =NULL, limits = c(as.Date(paste0(minYear-1,"-12-31")), as.Date(paste0(minYear+Tmax-1,"-12-01"))))+ #Here you would also have to edit the date range manually..
     geom_hline(yintercept = 0, color = "grey70")+
     dummy_guide(
-      labels = c("Reindeer carcasses (November-June)", "Rodent abundance autumn larger scale","Rodent abundance winter Varanger"), 
-      fill   = c("grey70", "#CF597EFF", "#005F94FF"),
+      labels = c("Rodent abundance autumn larger scale","Rodent abundance winter Varanger"), 
+      fill   = c("#CF597EFF", "#005F94FF"),
       colour = NA,
       key = draw_key_polygon) +
     theme_bw() + theme(panel.grid.minor = element_blank(), panel.grid.major.y = element_blank(), 

--- a/R/plotIPM_covariateEffects.R
+++ b/R/plotIPM_covariateEffects.R
@@ -7,10 +7,6 @@
 #' use for predictions. 
 #' @param rodentMAX numeric. Maximum value of z-standardized rodent covariate to 
 #' use for predictions. 
-#' @param reindeerMIN numeric. Minimum value of z-standardized reindeer covariate to 
-#' use for predictions. 
-#' @param reindeerMAX numeric. Maximum value of z-standardized reindeer covariate to 
-#' use for predictions. 
 #' @param AgeClass integer. Age class for which to make predictions. Implemented
 #' as "years of age" (range 0-4), not as model age index (range 1-5). 
 #'
@@ -20,7 +16,7 @@
 #'
 #' @examples
 
-plotIPM_covariateEffects <- function(MCMC.samples, rCov.idx, rodentMIN, rodentMAX, reindeerMIN, reindeerMAX, AgeClass){
+plotIPM_covariateEffects <- function(MCMC.samples, rCov.idx, rodentMIN, rodentMAX, AgeClass){
   
   ## Check if continuous rodent covariates have been used (categorical not supported yet)
   if(rCov.idx){
@@ -46,9 +42,8 @@ plotIPM_covariateEffects <- function(MCMC.samples, rCov.idx, rodentMIN, rodentMA
   ## Make posterior predictions for rodent covariate effects
   for(x in 1:length(rodentCov)){
     
-    Psi.pred <- rho.pred <- imm.pred <- rep(NA, nrow(out.mat))
-    mO.pred <- matrix(NA, nrow(out.mat), ncol = 3)
-    
+    mO.pred <- Psi.pred <- rho.pred <- imm.pred <- rep(NA, nrow(out.mat))
+
     for(i in 1:nrow(out.mat)){
       
       if(AgeClass > 0){
@@ -63,131 +58,62 @@ plotIPM_covariateEffects <- function(MCMC.samples, rCov.idx, rodentMIN, rodentMA
         Psi.pred[i] <- 0
         rho.pred[i] <- 0
       }
-
+      
       # Immigration rate
       imm.pred[i] <- exp(log(out.mat[i, "Mu.immR"]) + 
-                        out.mat[i, "betaR.immR"]*rodentCov[x])
+                           out.mat[i, "betaR.immR"]*rodentCov[x])
       
-      # Natural morality - for three levels of reindeer carcass abundance
-      mO.pred[i,] <- exp(log(out.mat[i, paste0("Mu.mO[", AgeClass + 1, "]")]) + 
-                           out.mat[i, "betaR.mO"]*rodentCov[x] + 
-                           out.mat[i, "betaRd.mO"]*c(-1, 0, 1) +
-                           out.mat[i, "betaRxRd.mO"]*rodentCov[x]*c(-1, 0, 1))
+      # Natural morality 
+      mO.pred[i] <- exp(log(out.mat[i, paste0("Mu.mO[", AgeClass + 1, "]")]) + 
+                          out.mat[i, "betaR.mO"]*rodentCov[x])
     }
     
     # Assemble in temporary data frame
     data.temp <- rbind(quantile(Psi.pred, probs = c(0.025, 0.5, 0.975)),
                        quantile(rho.pred, probs = c(0.025, 0.5, 0.975)),
                        quantile(imm.pred, probs = c(0.025, 0.5, 0.975)),
-                       quantile(mO.pred[,1], probs = c(0.025, 0.5, 0.975)),
-                       quantile(mO.pred[,2], probs = c(0.025, 0.5, 0.975)),
-                       quantile(mO.pred[,3], probs = c(0.025, 0.5, 0.975))) %>%
+                       quantile(mO.pred, probs = c(0.025, 0.5, 0.975))) %>%
       as.data.frame() %>%
       dplyr::rename(lCI = 1, median = 2, uCI = 3) %>%
-      dplyr::mutate(VitalRate = c("Pregnancy rate", "Fetus number", "Immigration rate", rep("Natural mortality", 3)),
-                    RodentAbundance = rodentCov[x], 
-                    ReindeerCarcass = c(rep(NA, 3), "Reindeer carcass: low (mean - sd)", "Reindeer carcass: average (mean)", "Reindeer carcass: high (mean + sd)"))
-      
+      dplyr::mutate(VitalRate = c("Pregnancy rate", "Fetus number", "Immigration rate", "Natural mortality"),
+                    RodentAbundance = rodentCov[x])
+    
     # Combine in main data frame
     covPred.data <- rbind(covPred.data, data.temp)
   }
-
+  
   ## Re-arrange factor levels
   covPred.data$VitalRate <- factor(covPred.data$VitalRate, levels = c("Natural mortality", "Pregnancy rate", "Fetus number", "Immigration rate"))
-  covPred.data$ReindeerCarcass <- factor(covPred.data$ReindeerCarcass, levels = c("Reindeer carcass: low (mean - sd)", "Reindeer carcass: average (mean)", "Reindeer carcass: high (mean + sd)"))
-  
-  #-------------------------------------#
-  # Make reindeer covariate predictions #
-  #-------------------------------------#
-  
-  ## Make vector of values for covariates for which to predict for
-  reindeerCov <- seq(reindeerMIN, reindeerMAX, length.out = 100)
-  
-  ## Set up empty dataframes to store results
-  covPred.data2 <- data.frame()
-  
-  ## Make posterior predictions for rodent covariate effects
-  for(x in 1:length(reindeerCov)){
-    for(i in 1:nrow(out.mat)){
-      
-      # Natural morality - for three levels of reindeer carcass abundance
-      mO.pred[i,] <- exp(log(out.mat[i, paste0("Mu.mO[", AgeClass + 1, "]")]) + 
-                           out.mat[i, "betaR.mO"]*c(-1, 0, 1) + 
-                           out.mat[i, "betaRd.mO"]*reindeerCov[x] +
-                           out.mat[i, "betaRxRd.mO"]*reindeerCov[x]*c(-1, 0, 1))
-    }
-    
-    # Assemble in temporary data frame
-    data.temp <- rbind(quantile(mO.pred[,1], probs = c(0.025, 0.5, 0.975)),
-                       quantile(mO.pred[,2], probs = c(0.025, 0.5, 0.975)),
-                       quantile(mO.pred[,3], probs = c(0.025, 0.5, 0.975))) %>%
-      as.data.frame() %>%
-      dplyr::rename(lCI = 1, median = 2, uCI = 3) %>%
-      dplyr::mutate(VitalRate = rep("Natural mortality", 3),
-                    RodentAbundance = c("Rodent abundance: low (mean - sd)", "Rodent abundance: average (mean)", "Rodent abundance: high (mean + sd)"), 
-                    ReindeerCarcass = reindeerCov[x])
-    
-    # Combine in main data frame
-    covPred.data2 <- rbind(covPred.data2, data.temp)
-  }
-  
-  ## Re-arrange factor levels
-  covPred.data2$RodentAbundance <- factor(covPred.data2$RodentAbundance, levels = c("Rodent abundance: low (mean - sd)", "Rodent abundance: average (mean)", "Rodent abundance: high (mean + sd)"))
-  
   
   #----------------------------#
   # Plot covariate predictions #
   #----------------------------#
   
   ## Rodent effects on pregnancy rate, fetus number, and immigration rate
-  p.Psi_rho_immR <- covPred.data %>%
-    dplyr::filter(VitalRate %in% c("Pregnancy rate", "Fetus number", "Immigration rate")) %>%
-    dplyr::mutate(VitalRate = factor(dplyr::case_when(VitalRate == "Pregnancy rate" ~ paste0("Pregnancy rate (age ", AgeClass, ")"),
-                                               VitalRate == "Fetus number" ~ paste0("Fetus number (age ", AgeClass, ")"),
-                                               TRUE ~ VitalRate), 
-                                     levels = c(paste0("Pregnancy rate (age ", AgeClass, ")"), paste0("Fetus number (age ", AgeClass, ")"), "Immigration rate"))) %>%
+  p.VRs <- covPred.data %>%
+    dplyr::mutate(VitalRate = factor(dplyr::case_when(VitalRate == "Natural mortality" ~ paste0("Natural mortality (age ", AgeClass, ")"),
+                                                      VitalRate == "Pregnancy rate" ~ paste0("Pregnancy rate (age ", AgeClass, ")"),
+                                                      VitalRate == "Fetus number" ~ paste0("Fetus number (age ", AgeClass, ")"),
+                                                      TRUE ~ VitalRate), 
+                                     levels = c(paste0("Natural mortality (age ", AgeClass, ")"), 
+                                                paste0("Pregnancy rate (age ", AgeClass, ")"), 
+                                                paste0("Fetus number (age ", AgeClass, ")"), 
+                                                "Immigration rate"))) %>%
     ggplot(aes(x = RodentAbundance)) + 
     geom_line(aes(y = median, color = VitalRate)) + 
     geom_ribbon(aes(ymin = lCI, ymax = uCI, fill = VitalRate), alpha = 0.5) + 
-    scale_color_manual(values = c("#52BA88FF", "#BED68AFF", "#E79069FF")) + 
-    scale_fill_manual(values = c("#52BA88FF", "#BED68AFF", "#E79069FF")) + 
+    scale_color_manual(values = c("#089392FF", "#52BA88FF", "#BED68AFF", "#E79069FF")) + 
+    scale_fill_manual(values = c("#089392FF", "#52BA88FF", "#BED68AFF", "#E79069FF")) + 
     ylab("Predicted value") + 
-    facet_wrap(~VitalRate, nrow = 1, scales = "free_y") + 
+    facet_wrap(~VitalRate, nrow = 2, scales = "free_y") + 
     theme_bw() + theme(panel.grid = element_blank(), legend.position = "none")
   
-  pdf("Plots/RedfoxIPM_rodentEff_Psi&rho&immR.pdf", width = 8, height = 3)
-  print(p.Psi_rho_immR)
+  pdf("Plots/RedfoxIPM_rodentEff_VitalRates.pdf", width = 8, height = 6)
+  print(p.VRs)
   dev.off()
-  
-  ## Rodent and reindeer effects on natural mortality 
-  
-  # Rodent effect per reindeer level
-  p.mO.R <- covPred.data %>%
-    dplyr::filter(VitalRate == "Natural mortality") %>%
-    ggplot(aes(x = RodentAbundance)) + 
-    geom_line(aes(y = median), color = "#089392FF") + 
-    geom_ribbon(aes(ymin = lCI, ymax = uCI), fill = "#089392FF", alpha = 0.5) + 
-    ylab("Natural mortality") + 
-    facet_wrap(~ReindeerCarcass, nrow = 1) + 
-    theme_bw() + theme(panel.grid = element_blank())
-  
-  # Reindeer effect per rodent level
-  p.mO.Rd <- covPred.data2 %>%
-    ggplot(aes(x = ReindeerCarcass)) + 
-    geom_line(aes(y = median), color = "#089392FF") + 
-    geom_ribbon(aes(ymin = lCI, ymax = uCI), fill = "#089392FF", alpha = 0.5) + 
-    ylab("Natural mortality") + 
-    facet_wrap(~RodentAbundance, nrow = 1) + 
-    theme_bw() + theme(panel.grid = element_blank())
-  
-  pdf("Plots/RedfoxIPM_covEff_mO.pdf", width = 8, height = 6)
-  print(p.mO.R / p.mO.Rd)
-  dev.off()
-  
   
   ## Return list of plots
-  plotList <- c("Plots/RedfoxIPM_rodentEff_Psi&rho&immR.pdf",
-                "Plots/RedfoxIPM_covEff_mO.pdf")
+  plotList <- c("Plots/RedfoxIPM_rodentEff_VitalRates.pdf")
   
   return(plotList)
 } 

--- a/R/plotVariance_comp_mO.R
+++ b/R/plotVariance_comp_mO.R
@@ -1,4 +1,4 @@
-#' Plot decomposition of variance in mO into covariates (rodent, reindeer and their interaction) and random effect
+#' Plot decomposition of variance in mO into covariates (rodent) and random effect
 #'
 #' @param MCMC.samples an mcmc list containing posterior samples from a model run.
 #' @param Tmax integer. Number of years to consider in the analysis
@@ -11,10 +11,10 @@ plotVariance_comp_mO <- function(MCMC.samples, Tmax, minYear){
   
   sam.mat <- as.matrix(MCMC.samples)
 
-  #For natural mortality there are two covariates and three effects, i.e. the formula is: 
-  #mO[a, t] <- exp(log(Mu.mO[a]) + betaRd.mO*Reindeer[t] + betaR.mO*RodentAbundance[t+1] + betaRxRd.mO*Reindeer[t]*RodentAbundance[t+1] + epsilon.mO[t])
-  #One can choose any age here because the covariates and random effect are modelled independent of age and age is therefore cancelled out
-  #we just choose age class 2 for now
+  # For natural mortality there is one covariate/effect, i.e. the formula is: 
+  # mO[a, t] <- exp(log(Mu.mO[a]) + betaR.mO*RodentAbundance[t+1] + epsilon.mO[t])
+  # One can choose any age here because the covariates and random effect are modelled independent of age and age is therefore cancelled out
+  # we just choose age class 2 for now
   a <-2
   testData.mO <- data.frame()
   nSamples <- nrow(sam.mat)
@@ -28,22 +28,13 @@ plotVariance_comp_mO <- function(MCMC.samples, Tmax, minYear){
     RodentAbundance <- sam.mat[ , paste0("RodentAbundance[", t+1, "]")] # t+1 because see formula above or in modelcode
     RodentEffect <- betaR.mO * RodentAbundance                          #see formula above or modelcode
     
-    #Posterior of parameter reindeer effect on natural mortality
-    betaRd.mO <- sam.mat[ , "betaRd.mO"]
-    Reindeer <- sam.mat[ , paste0("Reindeer[", t, "]")]                 #t because see formula above or in modelcode 
-    ReindeerEffect <- betaRd.mO * Reindeer                              #see formula above or modelcode
-    
-    #Posterior of parameter rodent x reindeer interaction effect on natural mortality
-    betaRxRd.mO <- sam.mat[ , "betaRxRd.mO"]
-    InteractionEffect <- betaRxRd.mO * Reindeer * RodentAbundance   #see formula above or modelcode 
-    
     #Random effect
     epsilon.mO <- sam.mat[, paste0("epsilon.mO[", t,"]")]
     
     testData_temp <- data.frame(
       Year = t,
-      Component = rep(c("Rodent covariate", "Reindeer covariate", "Rodent x Reindeer interaction" , "Random effect"), each = nSamples),
-      Value = c(RodentEffect, ReindeerEffect, InteractionEffect, epsilon.mO)
+      Component = rep(c("Rodent covariate", "Random effect"), each = nSamples),
+      Value = c(RodentEffect, epsilon.mO)
     )
     testData.mO <- rbind(testData.mO, testData_temp)
   }

--- a/R/setupModel.R
+++ b/R/setupModel.R
@@ -82,7 +82,7 @@ setupModel <- function(modelCode,
   }
   
   if(fitCov.mO){
-    params <- c(params, "betaRd.mO", "betaR.mO", "betaRxRd.mO", "Reindeer")
+    params <- c(params, "betaR.mO")
   }
   
   if(fitCov.Psi){

--- a/R/setupModel_PVA.R
+++ b/R/setupModel_PVA.R
@@ -82,7 +82,7 @@ setupModel_PVA <- function(modelCode,
   }
   
   if(fitCov.mO){
-    params <- c(params, "betaRd.mO", "betaR.mO", "betaRxRd.mO")
+    params <- c(params, "betaR.mO")
   }
   
   if(fitCov.Psi){

--- a/R/setupPerturbVecs_PVA.R
+++ b/R/setupPerturbVecs_PVA.R
@@ -47,10 +47,6 @@
 #' Default = FALSE. 
 #' @param factor.rodent numeric. Change to standardized rodent covariate 
 #' mean to apply. 1 = no change (default). < 1 = decrease. > 1 = increase. 
-#' @param pert.reindeer logical. Whether to apply a perturbation to reindeer 
-#' covariate. Default = FALSE. 
-#' @param factor.reindeer numeric. Change to standardized reindeer 
-#' covariate mean to apply. 1 = no change (default). < 1 = decrease. > 1 = increase. 
 #'
 #' @return
 #' @export
@@ -63,16 +59,15 @@ setupPerturbVecs_PVA <- function(Tmax, Tmax_sim,
                                  pert.S0 = FALSE, factor.S0 = 1,
                                  pert.mHs = FALSE, factor.mHs = 1,
                                  pert.immR = FALSE, factor.immR = 1,
-                                 pert.rodent = FALSE,  factor.rodent = 1,
-                                 pert.reindeer = FALSE, factor.reindeer = 1){
+                                 pert.rodent = FALSE,  factor.rodent = 1){
   
   ## Check that there are no invalid perturbation factors
-  if(any(c(factor.mH, factor.mO, factor.S0, factor.mHs, factor.immR, factor.rodent, factor.reindeer) < 0)){
+  if(any(c(factor.mH, factor.mO, factor.S0, factor.mHs, factor.immR, factor.rodent) < 0)){
     stop("Invalid perturbation factor provided. Perturbation factors have to be
          numerical values >= 0.")
   }
   
-  if(any(!is.numeric(c(factor.mH, factor.mO, factor.S0, factor.mHs, factor.immR, factor.rodent, factor.reindeer)))){
+  if(any(!is.numeric(c(factor.mH, factor.mO, factor.S0, factor.mHs, factor.immR, factor.rodent)))){
     stop("Invalid perturbation factor provided. Perturbation factors have to be
          numerical values >= 0.")
   }
@@ -80,7 +75,7 @@ setupPerturbVecs_PVA <- function(Tmax, Tmax_sim,
   ## Set up basics perturbation vectors during study/data period
   pertFac.mH <- pertFac.mO <- pertFac.mHs <- pertFac.immR <- rep(1, Tmax)
   pertFac.S0 <- rep(1, Tmax+1)
-  pertFac.rodent <- pertFac.reindeer <- rep(1, Tmax+1)
+  pertFac.rodent <- rep(1, Tmax+1)
   
   ## Add factors for perturbation period
   if(Tmax_sim > 0){
@@ -90,13 +85,12 @@ setupPerturbVecs_PVA <- function(Tmax, Tmax_sim,
     pertFac.mHs <- c(pertFac.mHs, rep(ifelse(pert.mHs, factor.mHs, 1), Tmax_sim))
     pertFac.immR <- c(pertFac.immR, rep(ifelse(pert.immR, factor.immR, 1), Tmax_sim))
     pertFac.rodent <- c(pertFac.rodent, rep(ifelse(pert.rodent, factor.rodent, 1), Tmax_sim))
-    pertFac.reindeer <- c(pertFac.reindeer, rep(ifelse(pert.reindeer, factor.reindeer, 1), Tmax_sim))
   }
   
   ## List and return perturbation vectors
   pertVecs <- list(pertFac.mH = pertFac.mH, pertFac.mO = pertFac.mO, 
                    pertFac.S0 = pertFac.S0, pertFac.mHs = pertFac.mHs, 
                    pertFac.immR = pertFac.immR,
-                   pertFac.rodent = pertFac.rodent, pertFac.reindeer = pertFac.reindeer)
+                   pertFac.rodent = pertFac.rodent)
   return(pertVecs)
 }

--- a/R/simulateInitVals.R
+++ b/R/simulateInitVals.R
@@ -79,12 +79,7 @@ simulateInitVals <- function(nim.data, nim.constants, minN1, maxN1, minImm, maxI
   if(NA %in% RodentIndex2){
     RodentIndex2[which(is.na(RodentIndex2))] <- sample(1:nLevels.rCov, length(which(is.na(RodentIndex2))))
   }
-  
-  ## Reindeer carcass abundance
-  Reindeer <- nim.data$Reindeer
-  if(NA %in% Reindeer){
-    Reindeer[which(is.na(Reindeer))] <- mean(Reindeer, na.rm = TRUE)
-  }
+
   
   #---------------------------------------------------#
   # Set initial values for vital rate base parameters #
@@ -178,12 +173,8 @@ simulateInitVals <- function(nim.data, nim.constants, minN1, maxN1, minImm, maxI
   # Rodent abundance and reindeer carcasses on mO
   if(fitCov.mO){
     betaR.mO <- runif(1, -0.2, 0)
-    betaRd.mO <- runif(1, -0.2, 0)
-    betaRxRd.mO <- runif(1, 0, 0.2)
   }else{
     betaR.mO <- 0
-    betaRd.mO <- 0
-    betaRxRd.mO <- 0
   }
   
   # Rodent abundance on Psi
@@ -253,7 +244,7 @@ simulateInitVals <- function(nim.data, nim.constants, minN1, maxN1, minImm, maxI
       mH[1:Amax, t] <- exp(log(Mu.mH[1:Amax]) + betaHE.mH*NHunters[t] + epsilon.mH[t])
       
       ## Other (natural) mortality hazard rate
-      mO[1:Amax, t] <- exp(log(Mu.mO[1:Amax]) + betaR.mO*RodentAbundance[t+1] + betaRd.mO*Reindeer[t] + betaRxRd.mO*RodentAbundance[t+1]*Reindeer[t] + epsilon.mO[t])
+      mO[1:Amax, t] <- exp(log(Mu.mO[1:Amax]) + betaR.mO*RodentAbundance[t+1] + epsilon.mO[t])
     }
     
     ## Pregnancy rate
@@ -451,9 +442,7 @@ simulateInitVals <- function(nim.data, nim.constants, minN1, maxN1, minImm, maxI
   }
   
   if(fitCov.mO){
-    InitVals$betaRd.mO <- betaRd.mO
     InitVals$betaR.mO <- betaR.mO
-    InitVals$betaRxRd.mO <- betaRxRd.mO
   }
   
   if(fitCov.Psi){
@@ -557,12 +546,6 @@ simulateInitVals <- function(nim.data, nim.constants, minN1, maxN1, minImm, maxI
     }
     
     
-  }
-
-  if(NA %in% nim.data$Reindeer){
-    Inits_Reindeer <- rep(NA, length(Reindeer))
-    Inits_Reindeer[which(is.na(nim.data$Reindeer))] <- Reindeer[which(is.na(nim.data$Reindeer))]
-    InitVals$Reindeer <- Inits_Reindeer
   }
   
   ## Return initial values

--- a/R/simulateInitVals_PVA.R
+++ b/R/simulateInitVals_PVA.R
@@ -53,11 +53,10 @@ simulateInitVals_PVA <- function(nim.data, nim.constants, minN1, maxN1, minImm, 
   pertFac.S0 <- nim.data$pertFac.S0
   pertFac.mHs <- nim.data$pertFac.mHs
   pertFac.immR <- nim.data$pertFac.immR
-  pertFac.reindeer <- nim.data$pertFac.reindeer
   pertFac.rodent <- nim.data$pertFac.rodent
   
-  if(any(c(pertFac.reindeer, pertFac.rodent) != 1)){
-    warning("Initial value simulation for scenarios with perturbations to covariates (rodents, reindeer) have not been tested throroughly yet and may not be implemented correctly.")
+  if(any(c(pertFac.rodent) != 1)){
+    warning("Initial value simulation for scenarios with perturbations to covariates (rodents) have not been tested throroughly yet and may not be implemented correctly.")
   }
   
   #-------------------------------------------------#
@@ -80,14 +79,6 @@ simulateInitVals_PVA <- function(nim.data, nim.constants, minN1, maxN1, minImm, 
   if(NA %in% RodentIndex2){
     RodentIndex2[which(is.na(RodentIndex2))] <- sample(1:nLevels.rCov, length(which(is.na(RodentIndex2))), replace = TRUE)
   }
-  
-  ## Reindeer carcass abundance
-  Reindeer <- nim.data$Reindeer
-  if(NA %in% Reindeer){
-    #Reindeer[which(is.na(Reindeer))] <- mean(Reindeer, na.rm = TRUE)
-    Reindeer[which(is.na(Reindeer))] <- 0
-  }
-  Reindeer_pert <- Reindeer + (1-pertFac.reindeer)
   
   ## Rodent abundance (continuous)
   RodentAbundance <- nim.data$RodentAbundance
@@ -208,15 +199,11 @@ simulateInitVals_PVA <- function(nim.data, nim.constants, minN1, maxN1, minImm, 
     betaHE.mH <- 0
   }
   
-  # Rodent abundance and reindeer carcasses on mO
+  # Rodent abundance on mO
   if(fitCov.mO){
     betaR.mO <- runif(1, -0.2, 0)
-    betaRd.mO <- runif(1, -0.2, 0)
-    betaRxRd.mO <- runif(1, 0, 0.2)
   }else{
     betaR.mO <- 0
-    betaRd.mO <- 0
-    betaRxRd.mO <- 0
   }
   
   # Rodent abundance on Psi
@@ -287,7 +274,7 @@ simulateInitVals_PVA <- function(nim.data, nim.constants, minN1, maxN1, minImm, 
       mH[1:Amax, t] <- exp(log(Mu.mH[1:Amax]) + betaHE.mH*NHunters[t] + epsilon.mH[t])*pertFac.mH[t]*pertFac.mH.flex[t]
       
       ## Other (natural) mortality hazard rate
-      mO[1:Amax, t] <- exp(log(Mu.mO[1:Amax]) + betaR.mO*RodentAbundance_pert[t+1] + betaRd.mO*Reindeer[t] + betaRxRd.mO*RodentAbundance_pert[t+1]*Reindeer[t] + epsilon.mO[t])*pertFac.mO[t]
+      mO[1:Amax, t] <- exp(log(Mu.mO[1:Amax]) + betaR.mO*RodentAbundance_pert[t+1] + epsilon.mO[t])*pertFac.mO[t]
     }
     
     ## Pregnancy rate
@@ -485,9 +472,7 @@ simulateInitVals_PVA <- function(nim.data, nim.constants, minN1, maxN1, minImm, 
   }
   
   if(fitCov.mO){
-    InitVals$betaRd.mO <- betaRd.mO
     InitVals$betaR.mO <- betaR.mO
-    InitVals$betaRxRd.mO <- betaRxRd.mO
   }
   
   if(fitCov.Psi){
@@ -570,12 +555,6 @@ simulateInitVals_PVA <- function(nim.data, nim.constants, minN1, maxN1, minImm, 
   }
   if(!rCov.idx & !poolYrs.genData){
     InitVals$RodentAbundance2_pre <- rnorm(nim.constants$Tmax_Gen_pre, mean = 0, sd = 1)
-  }
-  
-  if(NA %in% nim.data$Reindeer){
-    Inits_Reindeer <- rep(NA, length(Reindeer))
-    Inits_Reindeer[which(is.na(nim.data$Reindeer))] <- Reindeer[which(is.na(nim.data$Reindeer))]
-    InitVals$Reindeer <- Inits_Reindeer
   }
   
   ## Add perturbed covariate values

--- a/R/writeCode_redfoxIPM.R
+++ b/R/writeCode_redfoxIPM.R
@@ -298,7 +298,7 @@ writeCode_redfoxIPM <- function(indLikelihood.genData = FALSE){
         
         # Other (natural) mortality hazard rate
         if(fitCov.mO){
-          log(mO[1:Amax, t]) <- log(Mu.mO[1:Amax]) + betaRd.mO*Reindeer[t] + betaR.mO*RodentAbundance[t+1] + betaRxRd.mO*Reindeer[t]*RodentAbundance[t+1] + epsilon.mO[t]
+          log(mO[1:Amax, t]) <- log(Mu.mO[1:Amax]) + betaR.mO*RodentAbundance[t+1] + epsilon.mO[t]
         }else{
           log(mO[1:Amax, t]) <- log(Mu.mO[1:Amax]) + epsilon.mO[t]
         }
@@ -353,9 +353,7 @@ writeCode_redfoxIPM <- function(indLikelihood.genData = FALSE){
       }
       
       if(fitCov.mO){
-        betaRd.mO ~ dunif(-5, 0) # Effect of reindeer carcasses on mO
         betaR.mO ~ dunif(-5, 0) # Effect of rodent abundance on mO
-        betaRxRd.mO ~ dunif(-5, 5) # Interactive effect of reindeer x rodent on mO
       }
       
       
@@ -369,7 +367,7 @@ writeCode_redfoxIPM <- function(indLikelihood.genData = FALSE){
         
         if(fitCov.Psi){
           if(rCov.idx){
-            logit(Psi[2:Amax,t]) <- logit(Mu.Psi[2:Amax]) + betaR.Psi[RodentIndex[t]] + epsilon.Psi[t] # Reindeer.rodent interaction not (yet) written in
+            logit(Psi[2:Amax,t]) <- logit(Mu.Psi[2:Amax]) + betaR.Psi[RodentIndex[t]] + epsilon.Psi[t] 
           }else{
             logit(Psi[2:Amax,t]) <- logit(Mu.Psi[2:Amax]) + betaR.Psi*RodentAbundance[t] + epsilon.Psi[t]
           }
@@ -597,11 +595,6 @@ writeCode_redfoxIPM <- function(indLikelihood.genData = FALSE){
           RodentAbundance[t] ~ dnorm(0, sd = 1)
           RodentAbundance2[t] ~ dnorm(0, sd = 1)
         }
-      }
-      
-      ## Missing covariate values in reindeer information
-      for(t in 1:Tmax+1){
-        Reindeer[t] ~ dnorm(0, sd = 1)
       }
       
     })
@@ -861,7 +854,7 @@ writeCode_redfoxIPM <- function(indLikelihood.genData = FALSE){
         
         # Other (natural) mortality hazard rate
         if(fitCov.mO){
-          log(mO[1:Amax, t]) <- log(Mu.mO[1:Amax]) + betaRd.mO*Reindeer[t] + betaR.mO*RodentAbundance[t+1] + betaRxRd.mO*Reindeer[t]*RodentAbundance[t+1] + epsilon.mO[t]
+          log(mO[1:Amax, t]) <- log(Mu.mO[1:Amax]) + betaR.mO*RodentAbundance[t+1] + epsilon.mO[t]
         }else{
           log(mO[1:Amax, t]) <- log(Mu.mO[1:Amax]) + epsilon.mO[t]
         }
@@ -916,9 +909,7 @@ writeCode_redfoxIPM <- function(indLikelihood.genData = FALSE){
       }
       
       if(fitCov.mO){
-        betaRd.mO ~ dunif(-5, 0) # Effect of reindeer carcasses on mO
         betaR.mO ~ dunif(-5, 0) # Effect of rodent abundance on mO
-        betaRxRd.mO ~ dunif(-5, 5) # Interactive effect of reindeer x rodent on mO
       }
       
       
@@ -932,7 +923,7 @@ writeCode_redfoxIPM <- function(indLikelihood.genData = FALSE){
         
         if(fitCov.Psi){
           if(rCov.idx){
-            logit(Psi[2:Amax,t]) <- logit(Mu.Psi[2:Amax]) + betaR.Psi[RodentIndex[t]] + epsilon.Psi[t] # Reindeer.rodent interaction not (yet) written in
+            logit(Psi[2:Amax,t]) <- logit(Mu.Psi[2:Amax]) + betaR.Psi[RodentIndex[t]] + epsilon.Psi[t]
           }else{
             logit(Psi[2:Amax,t]) <- logit(Mu.Psi[2:Amax]) + betaR.Psi*RodentAbundance[t] + epsilon.Psi[t]
           }
@@ -1178,13 +1169,6 @@ writeCode_redfoxIPM <- function(indLikelihood.genData = FALSE){
           for(t in 1:Tmax_Gen_pre){
             RodentAbundance2_pre[t] ~ dnorm(0, sd = 1) 
           }
-        }
-      }
-      
-      ## Missing covariate values in reindeer information
-      if(fitCov.mO){
-        for(t in 1:Tmax+1){
-          Reindeer[t] ~ dnorm(0, sd = 1)
         }
       }
 

--- a/R/writeCode_redfoxIPM.R
+++ b/R/writeCode_redfoxIPM.R
@@ -353,7 +353,7 @@ writeCode_redfoxIPM <- function(indLikelihood.genData = FALSE){
       }
       
       if(fitCov.mO){
-        betaR.mO ~ dunif(-5, 0) # Effect of rodent abundance on mO
+        betaR.mO ~ dunif(-5, 5) # Effect of rodent abundance on mO
       }
       
       
@@ -909,7 +909,7 @@ writeCode_redfoxIPM <- function(indLikelihood.genData = FALSE){
       }
       
       if(fitCov.mO){
-        betaR.mO ~ dunif(-5, 0) # Effect of rodent abundance on mO
+        betaR.mO ~ dunif(-5, 5) # Effect of rodent abundance on mO
       }
       
       

--- a/R/writeCode_redfoxIPM_PVA.R
+++ b/R/writeCode_redfoxIPM_PVA.R
@@ -299,7 +299,7 @@ writeCode_redfoxIPM_PVA <- function(indLikelihood.genData = FALSE){
         
         # Other (natural) mortality hazard rate
         if(fitCov.mO){
-          mO[1:Amax, t] <- exp(log(Mu.mO[1:Amax]) + betaRd.mO*Reindeer[t] + betaR.mO*RodentAbundance_pert[t+1] + betaRxRd.mO*Reindeer[t]*RodentAbundance_pert[t+1] + epsilon.mO[t])*pertFac.mO[t]
+          mO[1:Amax, t] <- exp(log(Mu.mO[1:Amax]) + betaR.mO*RodentAbundance_pert[t+1] + epsilon.mO[t])*pertFac.mO[t]
         }else{
           mO[1:Amax, t] <- exp(log(Mu.mO[1:Amax]) + epsilon.mO[t])*pertFac.mO[t]
         }
@@ -354,9 +354,7 @@ writeCode_redfoxIPM_PVA <- function(indLikelihood.genData = FALSE){
       }
       
       if(fitCov.mO){
-        betaRd.mO ~ dunif(-5, 0) # Effect of reindeer carcasses on mO
         betaR.mO ~ dunif(-5, 0) # Effect of rodent abundance on mO
-        betaRxRd.mO ~ dunif(-5, 5) # Interactive effect of reindeer x rodent on mO
       }
       
       
@@ -585,11 +583,6 @@ writeCode_redfoxIPM_PVA <- function(indLikelihood.genData = FALSE){
         for(t in 1:(Tmax+Tmax_sim)){
           HarvestEffort[t] ~ dnorm(0, sd = 1)
         }
-      }
-      
-      ## Missing covariate values in reindeer information
-      for(t in 1:(Tmax+Tmax_sim+1)){
-        Reindeer[t] ~ dnorm(0 + (1-pertFac.reindeer[t]), sd = 1)
       }
       
       ## Missing covariate value(s) in rodent abundance
@@ -914,7 +907,7 @@ writeCode_redfoxIPM_PVA <- function(indLikelihood.genData = FALSE){
         
         # Other (natural) mortality hazard rate
         if(fitCov.mO){
-          mO[1:Amax, t] <- exp(log(Mu.mO[1:Amax]) + betaRd.mO*Reindeer[t] + betaR.mO*RodentAbundance_pert[t+1] + betaRxRd.mO*Reindeer[t]*RodentAbundance_pert[t+1] + epsilon.mO[t])*pertFac.mO[t]
+          mO[1:Amax, t] <- exp(log(Mu.mO[1:Amax]) + betaR.mO*RodentAbundance_pert[t+1] + epsilon.mO[t])*pertFac.mO[t]
         }else{
           mO[1:Amax, t] <- exp(log(Mu.mO[1:Amax]) + epsilon.mO[t])*pertFac.mO[t]
         }
@@ -969,9 +962,7 @@ writeCode_redfoxIPM_PVA <- function(indLikelihood.genData = FALSE){
       }
       
       if(fitCov.mO){
-        betaRd.mO ~ dunif(-5, 0) # Effect of reindeer carcasses on mO
         betaR.mO ~ dunif(-5, 0) # Effect of rodent abundance on mO
-        betaRxRd.mO ~ dunif(-5, 5) # Interactive effect of reindeer x rodent on mO
       }
       
       
@@ -1206,11 +1197,6 @@ writeCode_redfoxIPM_PVA <- function(indLikelihood.genData = FALSE){
         for(t in 1:(Tmax+Tmax_sim)){
           HarvestEffort[t] ~ dnorm(0, sd = 1)
         }
-      }
-      
-      ## Missing covariate values in reindeer information
-      for(t in 1:(Tmax+Tmax_sim+1)){
-        Reindeer[t] ~ dnorm(0 + (1-pertFac.reindeer[t]), sd = 1)
       }
       
       ## Missing covariate value(s) in rodent abundance

--- a/R/writeCode_redfoxIPM_PVA.R
+++ b/R/writeCode_redfoxIPM_PVA.R
@@ -354,7 +354,7 @@ writeCode_redfoxIPM_PVA <- function(indLikelihood.genData = FALSE){
       }
       
       if(fitCov.mO){
-        betaR.mO ~ dunif(-5, 0) # Effect of rodent abundance on mO
+        betaR.mO ~ dunif(-5, 5) # Effect of rodent abundance on mO
       }
       
       
@@ -962,7 +962,7 @@ writeCode_redfoxIPM_PVA <- function(indLikelihood.genData = FALSE){
       }
       
       if(fitCov.mO){
-        betaR.mO ~ dunif(-5, 0) # Effect of rodent abundance on mO
+        betaR.mO ~ dunif(-5, 5) # Effect of rodent abundance on mO
       }
       
       

--- a/R/writeCode_redfoxIndepMod.R
+++ b/R/writeCode_redfoxIndepMod.R
@@ -153,7 +153,7 @@ writeCode_redfoxIndepMod <- function(indLikelihood.genData = FALSE){
         
         # Other (natural) mortality hazard rate
         if(fitCov.mO){
-          log(mO[1:Amax, t]) <- log(Mu.mO[1:Amax]) + betaRd.mO*Reindeer[t] + betaR.mO*RodentAbundance[t+1] + betaRxRd.mO*Reindeer[t]*RodentAbundance[t+1] + epsilon.mO[t]
+          log(mO[1:Amax, t]) <- log(Mu.mO[1:Amax]) + betaR.mO*RodentAbundance[t+1] + epsilon.mO[t]
         }else{
           log(mO[1:Amax, t]) <- log(Mu.mO[1:Amax]) + epsilon.mO[t]
         }
@@ -208,9 +208,7 @@ writeCode_redfoxIndepMod <- function(indLikelihood.genData = FALSE){
       }
       
       if(fitCov.mO){
-        betaRd.mO ~ dunif(-5, 0) # Effect of reindeer carcasses on mO
         betaR.mO ~ dunif(-5, 0) # Effect of rodent abundance on mO
-        betaRxRd.mO ~ dunif(-5, 5) # Interactive effect of reindeer x rodent on mO
       }
       
       
@@ -224,7 +222,7 @@ writeCode_redfoxIndepMod <- function(indLikelihood.genData = FALSE){
         
         if(fitCov.Psi){
           if(rCov.idx){
-            logit(Psi[2:Amax,t]) <- logit(Mu.Psi[2:Amax]) + betaR.Psi[RodentIndex[t]] + epsilon.Psi[t] # Reindeer.rodent interaction not (yet) written in
+            logit(Psi[2:Amax,t]) <- logit(Mu.Psi[2:Amax]) + betaR.Psi[RodentIndex[t]] + epsilon.Psi[t]
           }else{
             logit(Psi[2:Amax,t]) <- logit(Mu.Psi[2:Amax]) + betaR.Psi*RodentAbundance[t] + epsilon.Psi[t]
           }
@@ -455,13 +453,6 @@ writeCode_redfoxIndepMod <- function(indLikelihood.genData = FALSE){
           for(t in 1:Tmax_Gen_pre){
             RodentAbundance2_pre[t] ~ dnorm(0, sd = 1) 
           }
-        }
-      }
-      
-      ## Missing covariate values in reindeer information
-      if(fitCov.mO){
-        for(t in 1:Tmax+1){
-          Reindeer[t] ~ dnorm(0, sd = 1)
         }
       }
       

--- a/RedFox_IPM_Analysis.R
+++ b/RedFox_IPM_Analysis.R
@@ -419,10 +419,9 @@ plotIPM_basicOutputs(MCMC.samples = IPM.out,
 
 ## Plot covariate relationships
 plotIPM_covariateEffects(MCMC.samples = IPM.out,
-                        rCov.idx = rCov.idx,
-                        rodentMIN = -1.75, rodentMAX = 4,
-                        reindeerMIN = -1.5, reindeerMAX = 1.5,
-                        AgeClass = 1) 
+                         rCov.idx = rCov.idx,
+                         rodentMIN = -1.75, rodentMAX = 4,
+                         AgeClass = 1) 
 
 #########################
 # 7) FOLLOW-UP ANALYSES #

--- a/RedFox_IPM_Analysis.R
+++ b/RedFox_IPM_Analysis.R
@@ -61,7 +61,7 @@ sourceDir('R')
 
 # Covariate toggles
 fitCov.mH <- FALSE # Fit covariates on mH (harvest effort)
-fitCov.mO <- TRUE # Fit covariates on mO (rodent abundance x reindeer carcasses)
+fitCov.mO <- TRUE # Fit covariates on mO (rodent abundance)
 fitCov.Psi <- TRUE # Fit covariates on Psi (rodent abundance)
 fitCov.rho <- TRUE # Fit covariates on rho (rodent abundance)
 fitCov.immR <- TRUE # Fit covariates on immigration rate (rodent abundance) - only if immigration is estimated as a rate

--- a/RedFox_IPM_Analysis_PVA.R
+++ b/RedFox_IPM_Analysis_PVA.R
@@ -382,7 +382,7 @@ IPM.out <- nimbleMCMC(code = model.setup$modelCode,
                       setSeed = 0)
 Sys.time() - t1
 
-saveRDS(IPM.out, file = "RedFoxIPM_sim_baseline_noReindeer.rds") # No perturbation
+saveRDS(IPM.out, file = "RedFoxIPM_sim_baseline_noReindeer2.rds") # No perturbation
 #saveRDS(IPM.out, file = "RedFoxIPM_sim_noHarvest.rds") # pert.mH = TRUE, mH.factor = 0
 #saveRDS(IPM.out, file = "RedFoxIPM_sim_higherHarvest_fac1.5.rds") # pert.mH = TRUE, mH.factor = 1.5 (initVals.seed = mySeed + 2 = 12)
 #saveRDS(IPM.out, file = "RedFoxIPM_sim_lowRodentHarvestMatch_th0_fac1.50.rds")
@@ -404,9 +404,11 @@ PVA0_comp <- compareModels(Amax = Amax,
                            maxYear = 2030,
                            logN = TRUE,
                            post.filepaths = c("RedFoxIPM_sim_baseline.rds", 
-                                              "RedFoxIPM_sim_baseline_noReindeer.rds"), 
+                                              "RedFoxIPM_sim_baseline_noReindeer.rds",
+                                              "RedFoxIPM_sim_baseline_noReindeer2.rds"), 
                            model.names = c("Original", 
-                                           "Without reindeer"), 
+                                           "Without reindeer, constrained",
+                                           "Without reindeer, unconstrained"), 
                            plotFolder = "Plots/ScenarioComp_PVA0_ReindeerCov",
                            returnSumData = TRUE)
 

--- a/RedFox_IPM_Analysis_PVA.R
+++ b/RedFox_IPM_Analysis_PVA.R
@@ -397,6 +397,20 @@ saveRDS(IPM.out, file = "RedFoxIPM_sim_baseline_noReindeer.rds") # No perturbati
 # 5) MODEL COMPARISONS #
 ########################
 
+## Models with/without reindeer covariate
+PVA0_comp <- compareModels(Amax = Amax, 
+                           Tmax = Tmax, 
+                           minYear = minYear, 
+                           maxYear = 2030,
+                           logN = TRUE,
+                           post.filepaths = c("RedFoxIPM_sim_baseline.rds", 
+                                              "RedFoxIPM_sim_baseline_noReindeer.rds"), 
+                           model.names = c("Original", 
+                                           "Without reindeer"), 
+                           plotFolder = "Plots/ScenarioComp_PVA0_ReindeerCov",
+                           returnSumData = TRUE)
+
+
 ## Baseline vs. no harvest
 PVA1_comp <- compareModels(Amax = Amax, 
                            Tmax = Tmax, 

--- a/RedFox_IPM_Analysis_PVA.R
+++ b/RedFox_IPM_Analysis_PVA.R
@@ -61,7 +61,7 @@ sourceDir('R')
 
 # Covariate toggles
 fitCov.mH <- FALSE # Fit covariates on mH (harvest effort)
-fitCov.mO <- TRUE # Fit covariates on mO (rodent abundance x reindeer carcasses)
+fitCov.mO <- TRUE # Fit covariates on mO (rodent abundance)
 fitCov.Psi <- TRUE # Fit covariates on Psi (rodent abundance)
 fitCov.rho <- TRUE # Fit covariates on rho (rodent abundance)
 fitCov.immR <- TRUE # Fit covariates on immigration rate (rodent abundance) - only if immigration is estimated as a rate
@@ -112,14 +112,12 @@ pert.mO <- FALSE
 pert.S0 <- FALSE
 pert.immR <- FALSE
 pert.rodent <- FALSE
-pert.reindeer <- FALSE
 
 factor.mH <- 1
 factor.mO <- 1
 factor.S0 <- 1
 factor.immR <- 1
 factor.rodent <- 1
-factor.reindeer <- 1
 
 if(pert.mH & factor.mH == 0){
   pert.mHs <- TRUE
@@ -135,8 +133,7 @@ perturbVecs <- setupPerturbVecs_PVA(Tmax = Tmax, Tmax_sim = Tmax_sim,
                                     pert.S0 = pert.S0, factor.S0 = factor.S0,
                                     pert.mHs = pert.mHs, factor.mHs = factor.mHs,
                                     pert.immR = pert.immR, factor.immR = factor.immR,
-                                    pert.rodent = pert.rodent, factor.rodent = factor.rodent,
-                                    pert.reindeer = pert.reindeer, factor.reindeer = factor.reindeer)
+                                    pert.rodent = pert.rodent, factor.rodent = factor.rodent)
 
 ## Set up perturbation parameters for running rodent-dependent harvest scenarios
 factor.mH.rodent <- 1
@@ -385,7 +382,7 @@ IPM.out <- nimbleMCMC(code = model.setup$modelCode,
                       setSeed = 0)
 Sys.time() - t1
 
-saveRDS(IPM.out, file = "RedFoxIPM_sim_baseline.rds") # No perturbation
+saveRDS(IPM.out, file = "RedFoxIPM_sim_baseline_noReindeer.rds") # No perturbation
 #saveRDS(IPM.out, file = "RedFoxIPM_sim_noHarvest.rds") # pert.mH = TRUE, mH.factor = 0
 #saveRDS(IPM.out, file = "RedFoxIPM_sim_higherHarvest_fac1.5.rds") # pert.mH = TRUE, mH.factor = 1.5 (initVals.seed = mySeed + 2 = 12)
 #saveRDS(IPM.out, file = "RedFoxIPM_sim_lowRodentHarvestMatch_th0_fac1.50.rds")

--- a/VredfoxIPM.Rproj
+++ b/VredfoxIPM.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: b80d09a6-5180-401d-97af-0e9c4a62cfa8
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/VredfoxIPM.Rproj
+++ b/VredfoxIPM.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: b80d09a6-5180-401d-97af-0e9c4a62cfa8
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
Following a suggestion from a reviewer of the article, we tested the effect of removing the reindeer covariate from the model. 

It turns out this simplification improves several model estimates and increases precision in forward projections (see issue #78 for details). 

We therefore drop the reindeer covariate from the main models with this merge, but retain the wrangling and preparation of the reindeer data in the workflow to allow re-adding it later if desired. 